### PR TITLE
实现跨域addAllowedOrigin改为addAllowedOriginPattern

### DIFF
--- a/48.Spring-Boot-CORS-Support/src/main/java/com/example/demo/config/WebConfigurer.java
+++ b/48.Spring-Boot-CORS-Support/src/main/java/com/example/demo/config/WebConfigurer.java
@@ -27,7 +27,7 @@ public class WebConfigurer implements WebMvcConfigurer {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.addAllowedOrigin("*");
+        config.addAllowedOriginPattern("*");
         source.registerCorsConfiguration("/**", config);
         FilterRegistrationBean bean = new FilterRegistrationBean(new CorsFilter(source));
         bean.setOrder(0);


### PR DESCRIPTION
config.addAllowedOrigin("*");方法实现不了跨域，需改为config.addAllowedOriginPattern("*");